### PR TITLE
Remove horizontal separators from bookmark menu

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -8,3 +8,7 @@
 #bookmarks-menu-button #BMB_viewBookmarksToolbar {
   display: none !important;
 }
+
+#BMB_bookmarksPopup menuseparator {
+  display: none;
+}


### PR DESCRIPTION
Solves issue #1 

Removes "ghost" horizontal separator lines of the removed entries.
These appeared after an update to the browser.